### PR TITLE
Add chord-aware lyrics player with auto-scroll

### DIFF
--- a/app/src/main/java/com/zionhuang/music/lyrics/player/ChordParser.kt
+++ b/app/src/main/java/com/zionhuang/music/lyrics/player/ChordParser.kt
@@ -1,0 +1,116 @@
+package com.zionhuang.music.lyrics.player
+
+/**
+ * Parser that extracts chord information from lyric lines with bracket notation.
+ */
+class ChordParser {
+    private val chordRegex = Regex("""\\[([^\\]]+)\\]""")
+    private val chordPattern = Regex("""^([A-G][#♯♭b]?)([^/]*)?(?:/([A-G][#♯♭b]?))?$""")
+
+    fun parseLine(input: String): LyricLine {
+        if (input.isEmpty()) {
+            return LyricLine(
+                raw = input,
+                cleanLyrics = "",
+                tokens = emptyList(),
+                chordSpans = emptyList()
+            )
+        }
+
+        val tokens = mutableListOf<Token>()
+        val chordAnchors = mutableListOf<Pair<Chord, Int>>()
+        var cleanText = input
+        var offset = 0
+
+        chordRegex.findAll(input).forEach { match ->
+            val chordText = match.groupValues[1]
+            val originalPosition = (match.range.first - offset).coerceAtLeast(0)
+            val chord = parseChord(chordText)
+
+            if (chord != null) {
+                chordAnchors.add(chord to originalPosition.coerceAtMost(cleanText.length))
+            }
+
+            cleanText = cleanText.replaceFirst(match.value, "")
+            offset += match.value.length
+        }
+
+        tokens += tokenizeText(cleanText, chordAnchors)
+
+        val chordSpans = computeChordSpans(cleanText, chordAnchors)
+
+        return LyricLine(
+            raw = input,
+            cleanLyrics = cleanText,
+            tokens = tokens,
+            chordSpans = chordSpans
+        )
+    }
+
+    fun parseChord(chordText: String): Chord? {
+        val normalized = chordText.replace("♯", "#").replace("♭", "b").trim()
+        val match = chordPattern.matchEntire(normalized) ?: return null
+
+        return Chord(
+            root = match.groupValues[1],
+            quality = match.groupValues[2].takeIf { it.isNotEmpty() },
+            bass = match.groupValues[3].takeIf { it.isNotEmpty() }
+        )
+    }
+
+    private fun computeChordSpans(text: String, anchors: List<Pair<Chord, Int>>): List<ChordSpan> {
+        if (anchors.isEmpty()) return emptyList()
+        val spans = anchors.map { (chord, charIndex) ->
+            val prefixLength = text.take(charIndex.coerceIn(0, text.length))
+            val column = prefixLength.codePointCount()
+            ChordSpan(
+                startColumn = column,
+                chord = chord,
+                width = chord.displayName.codePointCount().coerceAtLeast(1)
+            )
+        }.sortedBy { it.startColumn }
+        return spans.resolveCollisions()
+    }
+
+    private fun tokenizeText(text: String, anchors: List<Pair<Chord, Int>>): List<Token> {
+        if (text.isEmpty()) return emptyList()
+        val sortedAnchors = anchors.sortedBy { it.second }
+        val tokens = mutableListOf<Token>()
+        var index = 0
+        var anchorIndex = 0
+
+        fun emitAnchors(untilIndex: Int) {
+            while (anchorIndex < sortedAnchors.size && sortedAnchors[anchorIndex].second <= untilIndex) {
+                val (anchorChord, anchorPosition) = sortedAnchors[anchorIndex]
+                tokens += Token.ChordAnchor(anchorChord, anchorPosition.coerceIn(0, text.length))
+                anchorIndex++
+            }
+        }
+
+        while (index < text.length) {
+            emitAnchors(index)
+            val currentChar = text[index]
+            if (currentChar.isWhitespace()) {
+                val start = index
+                while (index < text.length && text[index].isWhitespace()) {
+                    index++
+                }
+                tokens += Token.Space(maxOf(1, index - start))
+            } else {
+                val start = index
+                while (index < text.length && !text[index].isWhitespace()) {
+                    index++
+                }
+                tokens += Token.Word(text.substring(start, index))
+            }
+        }
+
+        emitAnchors(text.length)
+        return tokens
+    }
+}
+
+private fun String.codePointCount(): Int =
+    if (isEmpty()) 0 else this.codePointCount(0, length)
+
+private fun Int.coerceAtLeast(min: Int) = if (this < min) min else this

--- a/app/src/main/java/com/zionhuang/music/lyrics/player/SongTextModels.kt
+++ b/app/src/main/java/com/zionhuang/music/lyrics/player/SongTextModels.kt
@@ -1,0 +1,84 @@
+package com.zionhuang.music.lyrics.player
+
+import kotlin.math.max
+
+/**
+ * Represents parsed song text with optional metadata and structured sections.
+ */
+data class SongText(
+    val id: String,
+    val title: String,
+    val artist: String?,
+    val sections: List<Section>
+)
+
+data class Section(
+    val tag: String?,
+    val lines: List<LyricLine>
+)
+
+data class LyricLine(
+    val raw: String,
+    val cleanLyrics: String,
+    val tokens: List<Token>,
+    val chordSpans: List<ChordSpan>
+)
+
+sealed interface Token {
+    data class Word(val text: String) : Token
+    data class Space(val length: Int = 1) : Token
+    data class ChordAnchor(val chord: Chord, val charIndex: Int) : Token
+}
+
+/**
+ * Representation of a parsed chord in the song text.
+ */
+data class Chord(
+    val root: String,
+    val quality: String?,
+    val bass: String?
+) {
+    val displayName: String get() = buildString {
+        append(root)
+        quality?.takeIf { it.isNotEmpty() }?.let { append(it) }
+        bass?.takeIf { it.isNotEmpty() }?.let { append("/$it") }
+    }
+}
+
+/**
+ * Indicates where a chord should be rendered relative to the lyric line.
+ *
+ * @param startColumn character-based column hint calculated from the clean lyrics.
+ * @param chord the chord that should be rendered.
+ * @param width the chord display length in characters, used for collision avoidance.
+ */
+data class ChordSpan(
+    val startColumn: Int,
+    val chord: Chord,
+    val width: Int
+)
+
+internal fun List<ChordSpan>.resolveCollisions(): List<ChordSpan> {
+    if (isEmpty()) return this
+    val resolved = ArrayList<ChordSpan>(size)
+    for (span in this) {
+        val previous = resolved.lastOrNull()
+        val adjustedColumn = if (previous != null) {
+            max(span.startColumn, previous.startColumn + previous.width + 1)
+        } else {
+            span.startColumn
+        }
+        resolved += span.copy(startColumn = adjustedColumn)
+    }
+    return resolved
+}
+
+fun SongText.hasLyrics(): Boolean =
+    sections.any { section ->
+        section.lines.any { line -> line.cleanLyrics.isNotBlank() }
+    }
+
+fun SongText.hasChords(): Boolean =
+    sections.any { section ->
+        section.lines.any { line -> line.chordSpans.isNotEmpty() }
+    }

--- a/app/src/main/java/com/zionhuang/music/lyrics/player/SongTextParser.kt
+++ b/app/src/main/java/com/zionhuang/music/lyrics/player/SongTextParser.kt
@@ -1,0 +1,86 @@
+package com.zionhuang.music.lyrics.player
+
+/**
+ * Splits raw song text into structured sections and lines while parsing chord annotations.
+ */
+class SongTextParser(
+    private val chordParser: ChordParser = ChordParser()
+) {
+    private val sectionBracketPattern = Regex("""^\[(.+)]$""")
+    private val sectionSuffixPattern = Regex("""^([A-Za-z].*?):$""")
+    private val chordOnlyPattern = Regex("""^([A-G][#♯♭b]?)([^/]*)?(?:/([A-G][#♯♭b]?))?$""")
+
+    fun parse(
+        id: String,
+        title: String,
+        artist: String?,
+        rawText: String
+    ): SongText {
+        val sections = mutableListOf<Section>()
+        var currentTag: String? = null
+        var currentLines = mutableListOf<LyricLine>()
+
+        fun commitSection() {
+            if (currentLines.isEmpty()) return
+            sections += Section(
+                tag = currentTag?.takeIf { it.isNotBlank() },
+                lines = currentLines.toList()
+            )
+            currentLines = mutableListOf()
+        }
+
+        rawText.lineSequence().forEach { rawLine ->
+            val trimmed = rawLine.trim()
+            val bracketMatch = sectionBracketPattern.matchEntire(trimmed)
+            val suffixMatch = sectionSuffixPattern.matchEntire(trimmed)
+
+            when {
+                trimmed.isEmpty() -> {
+                    currentLines += chordParser.parseLine("")
+                }
+                bracketMatch != null && !chordOnlyPattern.matches(bracketMatch.groupValues[1].trim()) -> {
+                    commitSection()
+                    currentTag = bracketMatch.groupValues[1].trim()
+                }
+                suffixMatch != null && !chordOnlyPattern.matches(suffixMatch.groupValues[1].trim()) -> {
+                    commitSection()
+                    currentTag = suffixMatch.groupValues[1].trim()
+                }
+                else -> {
+                    currentLines += chordParser.parseLine(rawLine)
+                }
+            }
+        }
+
+        commitSection()
+
+        val nonEmptySections = sections.filter { section ->
+            section.lines.any { it.cleanLyrics.isNotEmpty() || it.chordSpans.isNotEmpty() }
+        }
+
+        val finalSections = if (nonEmptySections.isEmpty()) {
+            listOf(
+                Section(
+                    tag = null,
+                    lines = listOf(
+                        LyricLine(
+                            raw = "",
+                            cleanLyrics = "",
+                            tokens = emptyList(),
+                            chordSpans = emptyList()
+                        )
+                    )
+                )
+            )
+        } else {
+            nonEmptySections
+        }
+
+        return SongText(
+            id = id,
+            title = title,
+            artist = artist,
+            sections = finalSections
+        )
+    }
+}

--- a/app/src/main/java/com/zionhuang/music/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/component/Lyrics.kt
@@ -52,14 +52,16 @@ import com.zionhuang.music.R
 import com.zionhuang.music.constants.PlayerTextAlignmentKey
 import com.zionhuang.music.constants.TranslateLyricsKey
 import com.zionhuang.music.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
-import com.zionhuang.music.lyrics.LyricsEntry
 import com.zionhuang.music.lyrics.LyricsEntry.Companion.HEAD_LYRICS_ENTRY
 import com.zionhuang.music.lyrics.LyricsUtils.findCurrentLineIndex
 import com.zionhuang.music.lyrics.LyricsUtils.parseLyrics
+import com.zionhuang.music.lyrics.LyricsEntry
+import com.zionhuang.music.lyrics.player.SongTextParser
 import com.zionhuang.music.ui.component.shimmer.ShimmerHost
 import com.zionhuang.music.ui.component.shimmer.TextPlaceholder
 import com.zionhuang.music.ui.menu.LyricsMenu
 import com.zionhuang.music.ui.screens.settings.PlayerTextAlignment
+import com.zionhuang.music.ui.component.playertext.PlayerTextScreen
 import com.zionhuang.music.ui.utils.fadingEdge
 import com.zionhuang.music.utils.rememberEnumPreference
 import com.zionhuang.music.utils.rememberPreference
@@ -94,6 +96,33 @@ fun Lyrics(
     }
     val isSynced = remember(lyrics) {
         !lyrics.isNullOrEmpty() && lyrics.startsWith("[")
+    }
+
+    val songTextParser = remember { SongTextParser() }
+    val showTextPlayer = remember(lyrics, translating) {
+        !translating && !lyrics.isNullOrEmpty() && lyrics != LYRICS_NOT_FOUND && !lyrics.startsWith("[")
+    }
+    val songText = remember(showTextPlayer, lyrics, mediaMetadata) {
+        if (!showTextPlayer) {
+            null
+        } else {
+            val currentLyrics = lyrics ?: return@remember null
+            runCatching {
+                val title = mediaMetadata?.title?.takeIf { it.isNotBlank() }
+                    ?: mediaMetadata?.id
+                    ?: "Song"
+                val artist = mediaMetadata?.artists
+                    ?.joinToString(separator = ", ") { it.name }
+                    ?.takeIf { it.isNotBlank() }
+                val songId = mediaMetadata?.id ?: title.hashCode().toString()
+                songTextParser.parse(
+                    id = songId,
+                    title = title,
+                    artist = artist,
+                    rawText = currentLyrics
+                )
+            }.getOrNull()
+        }
     }
 
     var currentLineIndex by remember {
@@ -156,70 +185,77 @@ fun Lyrics(
             .fillMaxSize()
             .padding(bottom = 12.dp)
     ) {
-        LazyColumn(
-            state = lazyListState,
-            contentPadding = WindowInsets.systemBars
-                .only(WindowInsetsSides.Top)
-                .add(WindowInsets(top = maxHeight / 2, bottom = maxHeight / 2))
-                .asPaddingValues(),
-            modifier = Modifier
-                .fadingEdge(vertical = 64.dp)
-                .nestedScroll(remember {
-                    object : NestedScrollConnection {
-                        override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
-                            lastPreviewTime = System.currentTimeMillis()
-                            return super.onPostScroll(consumed, available, source)
-                        }
-
-                        override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-                            lastPreviewTime = System.currentTimeMillis()
-                            return super.onPostFling(consumed, available)
-                        }
-                    }
-                })
-        ) {
-            val displayedCurrentLineIndex = if (isSeeking) deferredCurrentLineIndex else currentLineIndex
-
-            if (lyrics == null || translating) {
-                item {
-                    ShimmerHost {
-                        repeat(10) {
-                            Box(
-                                contentAlignment = when (playerTextAlignment) {
-                                    PlayerTextAlignment.SIDED -> Alignment.CenterStart
-                                    PlayerTextAlignment.CENTER -> Alignment.Center
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 24.dp, vertical = 4.dp)
-                            ) {
-                                TextPlaceholder()
-                            }
+        when {
+            lyrics == null || translating -> {
+                ShimmerHost {
+                    repeat(10) {
+                        Box(
+                            contentAlignment = when (playerTextAlignment) {
+                                PlayerTextAlignment.SIDED -> Alignment.CenterStart
+                                PlayerTextAlignment.CENTER -> Alignment.Center
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp, vertical = 4.dp)
+                        ) {
+                            TextPlaceholder()
                         }
                     }
                 }
-            } else {
-                itemsIndexed(
-                    items = lines
-                ) { index, item ->
-                    Text(
-                        text = item.text,
-                        fontSize = 20.sp,
-                        color = if (index == displayedCurrentLineIndex) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondary,
-                        textAlign = when (playerTextAlignment) {
-                            PlayerTextAlignment.SIDED -> TextAlign.Start
-                            PlayerTextAlignment.CENTER -> TextAlign.Center
-                        },
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable(enabled = isSynced) {
-                                playerConnection.player.seekTo(item.time)
-                                lastPreviewTime = 0L
+            }
+            showTextPlayer && songText != null -> {
+                PlayerTextScreen(
+                    songText = songText,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            else -> {
+                LazyColumn(
+                    state = lazyListState,
+                    contentPadding = WindowInsets.systemBars
+                        .only(WindowInsetsSides.Top)
+                        .add(WindowInsets(top = maxHeight / 2, bottom = maxHeight / 2))
+                        .asPaddingValues(),
+                    modifier = Modifier
+                        .fadingEdge(vertical = 64.dp)
+                        .nestedScroll(remember {
+                            object : NestedScrollConnection {
+                                override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+                                    lastPreviewTime = System.currentTimeMillis()
+                                    return super.onPostScroll(consumed, available, source)
+                                }
+
+                                override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                                    lastPreviewTime = System.currentTimeMillis()
+                                    return super.onPostFling(consumed, available)
+                                }
                             }
-                            .padding(horizontal = 24.dp, vertical = 8.dp)
-                            .alpha(if (!isSynced || index == displayedCurrentLineIndex) 1f else 0.5f)
-                    )
+                        })
+                ) {
+                    val displayedCurrentLineIndex = if (isSeeking) deferredCurrentLineIndex else currentLineIndex
+
+                    itemsIndexed(
+                        items = lines
+                    ) { index, item ->
+                        Text(
+                            text = item.text,
+                            fontSize = 20.sp,
+                            color = if (index == displayedCurrentLineIndex) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondary,
+                            textAlign = when (playerTextAlignment) {
+                                PlayerTextAlignment.SIDED -> TextAlign.Start
+                                PlayerTextAlignment.CENTER -> TextAlign.Center
+                            },
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable(enabled = isSynced) {
+                                    playerConnection.player.seekTo(item.time)
+                                    lastPreviewTime = 0L
+                                }
+                                .padding(horizontal = 24.dp, vertical = 8.dp)
+                                .alpha(if (!isSynced || index == displayedCurrentLineIndex) 1f else 0.5f)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/zionhuang/music/ui/component/playertext/AutoScrollController.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/component/playertext/AutoScrollController.kt
@@ -1,0 +1,62 @@
+package com.zionhuang.music.ui.component.playertext
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class AutoScrollController(
+    private val listState: LazyListState,
+    private val coroutineScope: CoroutineScope
+) {
+    private var scrollJob: Job? = null
+    private var isUserInteracting: Boolean = false
+
+    fun startAutoScroll(speedFactor: Float, density: Density, baseSpeed: Dp = 40.dp) {
+        stopAutoScroll()
+        val clampedSpeed = speedFactor.coerceIn(0f, 1f)
+        scrollJob = coroutineScope.launch {
+            var lastFrameTime = 0L
+            val baseSpeedPxPerSecond = with(density) { (baseSpeed * clampedSpeed).toPx() }
+            while (isActive) {
+                if (isUserInteracting || baseSpeedPxPerSecond == 0f) {
+                    lastFrameTime = 0L
+                    delay(32)
+                    continue
+                }
+                var scrollDistance = 0f
+                withFrameNanos { frameTime ->
+                    if (lastFrameTime != 0L) {
+                        val deltaSeconds = (frameTime - lastFrameTime) / 1_000_000_000f
+                        scrollDistance = baseSpeedPxPerSecond * deltaSeconds
+                    }
+                    lastFrameTime = frameTime
+                }
+                if (scrollDistance != 0f) {
+                    listState.scrollBy(scrollDistance)
+                } else {
+                    delay(16)
+                }
+            }
+        }
+    }
+
+    fun stopAutoScroll() {
+        scrollJob?.cancel()
+        scrollJob = null
+    }
+
+    fun pauseForUserInteraction() {
+        isUserInteracting = true
+    }
+
+    fun resumeAfterUserInteraction() {
+        isUserInteracting = false
+    }
+}

--- a/app/src/main/java/com/zionhuang/music/ui/component/playertext/PlayerTextScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/component/playertext/PlayerTextScreen.kt
@@ -1,0 +1,496 @@
+package com.zionhuang.music.ui.component.playertext
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.zionhuang.music.lyrics.player.LyricLine
+import com.zionhuang.music.lyrics.player.SongText
+import com.zionhuang.music.lyrics.player.hasChords
+import com.zionhuang.music.lyrics.player.hasLyrics
+import com.zionhuang.music.viewmodels.PlayerAction
+import com.zionhuang.music.viewmodels.PlayerTextViewModel
+import com.zionhuang.music.viewmodels.ViewMode
+import kotlinx.coroutines.delay
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlayerTextScreen(
+    songText: SongText,
+    modifier: Modifier = Modifier,
+    viewModel: PlayerTextViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    LaunchedEffect(songText) {
+        viewModel.setSong(songText)
+    }
+
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+    val autoScrollController = remember(listState, coroutineScope) {
+        AutoScrollController(listState, coroutineScope)
+    }
+    val density = LocalDensity.current
+
+    DisposableEffect(Unit) {
+        onDispose { autoScrollController.stopAutoScroll() }
+    }
+
+    LaunchedEffect(uiState.autoScrollEnabled, uiState.autoScrollSpeed, density) {
+        if (uiState.autoScrollEnabled) {
+            autoScrollController.startAutoScroll(uiState.autoScrollSpeed, density)
+        } else {
+            autoScrollController.stopAutoScroll()
+        }
+    }
+
+    var showSpeedControl by rememberSaveable { mutableStateOf(false) }
+
+    val hasLyrics = uiState.currentSong?.hasLyrics() == true
+    val hasChords = uiState.currentSong?.hasChords() == true
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            if (hasLyrics || hasChords) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    ViewModeSelector(
+                        currentMode = uiState.viewMode,
+                        hasLyrics = hasLyrics,
+                        hasChords = hasChords,
+                        onModeChange = { mode ->
+                            viewModel.handleAction(PlayerAction.SwitchView(mode))
+                        }
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    IconButton(onClick = { showSpeedControl = true }) {
+                        Icon(
+                            imageVector = if (uiState.autoScrollEnabled) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                            contentDescription = null
+                        )
+                    }
+                }
+            }
+
+            AutoScrollDetector(
+                controller = autoScrollController,
+                modifier = Modifier.weight(1f)
+            ) {
+                when (uiState.viewMode) {
+                    ViewMode.LYRICS -> LyricsView(
+                        songText = songText,
+                        listState = listState,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                    ViewMode.CHORDS -> ChordsView(
+                        songText = songText,
+                        listState = listState,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+        }
+
+        FloatingActionButton(
+            onClick = { showSpeedControl = true },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+        ) {
+            Icon(
+                imageVector = if (uiState.autoScrollEnabled) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                contentDescription = null
+            )
+        }
+
+        if (showSpeedControl) {
+            SpeedControlBottomSheet(
+                currentSpeed = uiState.autoScrollSpeed,
+                isEnabled = uiState.autoScrollEnabled,
+                onSpeedChange = { speed ->
+                    viewModel.handleAction(PlayerAction.SetAutoScrollSpeed(speed))
+                    if (uiState.autoScrollEnabled) {
+                        autoScrollController.startAutoScroll(speed, density)
+                    }
+                },
+                onToggleEnabled = { enabled ->
+                    viewModel.handleAction(PlayerAction.SetAutoScrollEnabled(enabled))
+                    if (!enabled) {
+                        autoScrollController.stopAutoScroll()
+                    } else {
+                        autoScrollController.startAutoScroll(uiState.autoScrollSpeed, density)
+                    }
+                },
+                onDismiss = { showSpeedControl = false }
+            )
+        }
+    }
+}
+
+@Composable
+fun AutoScrollDetector(
+    controller: AutoScrollController,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    var isDragging by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isDragging) {
+        if (isDragging) {
+            controller.pauseForUserInteraction()
+        } else {
+            delay(500)
+            controller.resumeAfterUserInteraction()
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = { isDragging = true },
+                    onDragEnd = { isDragging = false }
+                ) { _, _ -> }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onPress = {
+                        controller.pauseForUserInteraction()
+                        try {
+                            tryAwaitRelease()
+                        } finally {
+                            controller.resumeAfterUserInteraction()
+                        }
+                    }
+                )
+            }
+    ) {
+        content()
+    }
+}
+
+@Composable
+fun ViewModeSelector(
+    currentMode: ViewMode,
+    hasLyrics: Boolean,
+    hasChords: Boolean,
+    onModeChange: (ViewMode) -> Unit
+) {
+    SingleChoiceSegmentedButtonRow {
+        SegmentedButton(
+            selected = currentMode == ViewMode.LYRICS,
+            onClick = { onModeChange(ViewMode.LYRICS) },
+            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+            enabled = hasLyrics
+        ) {
+            Text(text = "Lyrics")
+        }
+        SegmentedButton(
+            selected = currentMode == ViewMode.CHORDS,
+            onClick = { onModeChange(ViewMode.CHORDS) },
+            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+            enabled = hasChords
+        ) {
+            Text(text = "Chords")
+        }
+    }
+}
+
+@Composable
+fun LyricsView(
+    songText: SongText,
+    listState: LazyListState,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        state = listState,
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        songText.sections.forEach { section ->
+            if (!section.tag.isNullOrEmpty()) {
+                item(key = "section_${section.tag}") {
+                    Text(
+                        text = section.tag,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                    )
+                }
+            }
+
+            items(
+                items = section.lines,
+                key = { line -> line.raw.hashCode() }
+            ) { line ->
+                Text(
+                    text = line.cleanLyrics,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.3f
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp)
+                )
+            }
+        }
+
+        if (!songText.hasLyrics()) {
+            item {
+                EmptyStateMessage(
+                    message = "No lyrics available for this song",
+                    modifier = Modifier.padding(32.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ChordsView(
+    songText: SongText,
+    listState: LazyListState,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        state = listState,
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        songText.sections.forEach { section ->
+            if (!section.tag.isNullOrEmpty()) {
+                item(key = "section_${section.tag}") {
+                    Text(
+                        text = section.tag,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                    )
+                }
+            }
+
+            items(
+                items = section.lines,
+                key = { line -> line.raw.hashCode() }
+            ) { line ->
+                ChordLyricLine(
+                    line = line,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+
+        if (!songText.hasChords()) {
+            item {
+                EmptyStateMessage(
+                    message = "No chords available for this song",
+                    modifier = Modifier.padding(32.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ChordLyricLine(
+    line: LyricLine,
+    modifier: Modifier = Modifier
+) {
+    val density = LocalDensity.current
+    var layoutResult by remember { mutableStateOf<androidx.compose.ui.text.TextLayoutResult?>(null) }
+
+    Column(modifier = modifier.padding(vertical = 4.dp)) {
+        if (line.chordSpans.isNotEmpty()) {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                line.chordSpans.forEach { span ->
+                    val offsetX = layoutResult?.let { result ->
+                        val index = span.startColumn.coerceIn(0, line.cleanLyrics.length)
+                        val cursorRect = result.getCursorRect(index)
+                        with(density) { cursorRect.left.toDp() }
+                    } ?: 0.dp
+                    Text(
+                        text = span.chord.displayName,
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier
+                            .padding(bottom = 2.dp)
+                            .offset(x = offsetX)
+                    )
+                }
+            }
+        }
+
+        Text(
+            text = line.cleanLyrics,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.3f
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = if (line.chordSpans.isNotEmpty()) 4.dp else 0.dp),
+            onTextLayout = { layoutResult = it }
+        )
+    }
+}
+
+@Composable
+fun EmptyStateMessage(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SpeedControlBottomSheet(
+    currentSpeed: Float,
+    isEnabled: Boolean,
+    onSpeedChange: (Float) -> Unit,
+    onToggleEnabled: (Boolean) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = "Auto-Scroll Speed",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            ) {
+                Text("Enable Auto-Scroll")
+                Switch(
+                    checked = isEnabled,
+                    onCheckedChange = onToggleEnabled
+                )
+            }
+
+            Text(
+                text = "Speed: ${(currentSpeed * 100).roundToInt()}%",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            Slider(
+                value = currentSpeed,
+                onValueChange = onSpeedChange,
+                enabled = isEnabled,
+                valueRange = 0f..1f,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+            ) {
+                SpeedPresetButton("Slow", 0.2f, onSpeedChange, isEnabled)
+                SpeedPresetButton("Medium", 0.4f, onSpeedChange, isEnabled)
+                SpeedPresetButton("Fast", 0.7f, onSpeedChange, isEnabled)
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+fun SpeedPresetButton(
+    label: String,
+    speed: Float,
+    onSpeedChange: (Float) -> Unit,
+    enabled: Boolean
+) {
+    OutlinedButton(
+        onClick = { onSpeedChange(speed) },
+        enabled = enabled
+    ) {
+        Text(label)
+    }
+}

--- a/app/src/main/java/com/zionhuang/music/viewmodels/PlayerTextViewModel.kt
+++ b/app/src/main/java/com/zionhuang/music/viewmodels/PlayerTextViewModel.kt
@@ -1,0 +1,86 @@
+package com.zionhuang.music.viewmodels
+
+import androidx.lifecycle.ViewModel
+import com.zionhuang.music.lyrics.player.SongText
+import com.zionhuang.music.lyrics.player.hasChords
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+enum class ViewMode { LYRICS, CHORDS }
+
+data class PlayerUiState(
+    val currentSong: SongText? = null,
+    val viewMode: ViewMode = ViewMode.LYRICS,
+    val autoScrollEnabled: Boolean = false,
+    val autoScrollSpeed: Float = 0.4f,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+sealed interface PlayerAction {
+    data class SwitchView(val mode: ViewMode) : PlayerAction
+    data class SetAutoScrollEnabled(val enabled: Boolean) : PlayerAction
+    data class SetAutoScrollSpeed(val speed: Float) : PlayerAction
+    object PauseAutoScroll : PlayerAction
+    object ResumeAutoScroll : PlayerAction
+}
+
+class PlayerTextViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(PlayerUiState())
+    val uiState: StateFlow<PlayerUiState> = _uiState.asStateFlow()
+
+    fun setSong(songText: SongText?) {
+        _uiState.update { state ->
+            val newMode = if (songText?.hasChords() == true) ViewMode.CHORDS else ViewMode.LYRICS
+            state.copy(
+                currentSong = songText,
+                viewMode = newMode,
+                isLoading = false,
+                error = null
+            )
+        }
+    }
+
+    fun handleAction(action: PlayerAction) {
+        when (action) {
+            is PlayerAction.SwitchView -> updateViewMode(action.mode)
+            is PlayerAction.SetAutoScrollEnabled -> setAutoScrollEnabled(action.enabled)
+            is PlayerAction.SetAutoScrollSpeed -> setAutoScrollSpeed(action.speed)
+            PlayerAction.PauseAutoScroll -> setAutoScrollEnabled(false)
+            PlayerAction.ResumeAutoScroll -> setAutoScrollEnabled(true)
+        }
+    }
+
+    private fun updateViewMode(mode: ViewMode) {
+        _uiState.update { state ->
+            if (state.currentSong?.hasChords() == true || mode == ViewMode.LYRICS) {
+                state.copy(viewMode = mode)
+            } else {
+                state
+            }
+        }
+    }
+
+    private fun setAutoScrollEnabled(enabled: Boolean) {
+        _uiState.update { it.copy(autoScrollEnabled = enabled) }
+    }
+
+    private fun setAutoScrollSpeed(speed: Float) {
+        val clamped = speed.coerceIn(0f, 1f)
+        _uiState.update { it.copy(autoScrollSpeed = clamped) }
+    }
+
+    fun showLoading() {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+    }
+
+    fun postError(message: String?) {
+        _uiState.update { it.copy(error = message, isLoading = false) }
+    }
+
+    fun resetAutoScroll() {
+        _uiState.update { it.copy(autoScrollEnabled = false) }
+    }
+}


### PR DESCRIPTION
## Summary
- add structured song text models and chord parsing helpers for bracketed notation
- build a player text screen with chord/lyric view modes, auto-scroll controls, and supporting view model logic
- integrate the new screen into the lyrics component for non-synced text content

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: missing Java toolchain in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cedca0a218832a834ac406d0cfaf21