### PR TITLE
Add chord-aware lyrics display with auto-scroll

### DIFF
--- a/app/src/main/java/com/zionhuang/music/lyrics/chords/ChordParser.kt
+++ b/app/src/main/java/com/zionhuang/music/lyrics/chords/ChordParser.kt
@@ -1,0 +1,226 @@
+package com.zionhuang.music.lyrics.chords
+
+import kotlin.math.max
+
+open class ChordParser {
+    private val chordRegex = Regex("""\\[([^]]+)\\]""")
+    private val chordPattern = Regex("""^([A-G][#♯♭b]?)([^/]*)?(?:/([A-G][#♯♭b]?))?$""")
+
+    open fun parseLine(input: String): LyricLine {
+        if (input.isEmpty()) {
+            return LyricLine(
+                raw = input,
+                cleanLyrics = "",
+                tokens = emptyList(),
+                chordSpans = emptyList()
+            )
+        }
+
+        val anchors = mutableListOf<Pair<Chord, Int>>()
+        val cleanBuilder = StringBuilder()
+        var lastIndex = 0
+
+        chordRegex.findAll(input).forEach { match ->
+            val chordText = match.groupValues[1]
+            val normalizedChord = parseChord(chordText)
+
+            val fragment = input.substring(lastIndex, match.range.first)
+            cleanBuilder.append(fragment)
+
+            normalizedChord?.let { chord ->
+                anchors += chord to cleanBuilder.codePointCount()
+            }
+
+            lastIndex = match.range.last + 1
+        }
+
+        if (lastIndex < input.length) {
+            cleanBuilder.append(input.substring(lastIndex))
+        }
+
+        val cleanText = cleanBuilder.toString()
+        val sortedAnchors = anchors.sortedBy { it.second }
+        val tokens = tokenizeText(cleanText, sortedAnchors)
+        val chordSpans = computeChordSpans(cleanText, sortedAnchors)
+
+        return LyricLine(
+            raw = input,
+            cleanLyrics = cleanText,
+            tokens = tokens,
+            chordSpans = chordSpans
+        )
+    }
+
+    fun parseSongText(id: String, title: String, artist: String?, rawText: String): SongText {
+        val sections = mutableListOf<Section>()
+        val currentLines = mutableListOf<LyricLine>()
+        var currentTag: String? = null
+
+        fun commitSection() {
+            if (currentLines.isNotEmpty()) {
+                sections += Section(
+                    tag = currentTag?.ifBlank { null },
+                    lines = currentLines.toList()
+                )
+                currentLines.clear()
+            }
+            currentTag = null
+        }
+
+        rawText.lines().forEach { rawLine ->
+            val normalizedLine = rawLine.trimEnd('\r')
+            val trimmedLine = normalizedLine.trim()
+            if (trimmedLine.isEmpty()) {
+                commitSection()
+            } else if (trimmedLine.endsWith(":") && currentLines.isEmpty()) {
+                currentTag = trimmedLine.dropLast(1).trim().ifBlank { null }
+            } else {
+                currentLines += parseLine(normalizedLine)
+            }
+        }
+        commitSection()
+
+        val resolvedSections = if (sections.isEmpty() && currentLines.isEmpty()) {
+            val fallbackLines = rawText.lines()
+                .filter { it.isNotEmpty() }
+                .map { parseLine(it.trimEnd('\r')) }
+            if (fallbackLines.isEmpty()) emptyList() else listOf(Section(null, fallbackLines))
+        } else sections
+
+        return SongText(
+            id = id,
+            title = title,
+            artist = artist,
+            sections = resolvedSections
+        )
+    }
+
+    fun containsChordNotation(text: String): Boolean {
+        return chordRegex.findAll(text).any { match ->
+            parseChord(match.groupValues[1]) != null
+        }
+    }
+
+    protected open fun parseChord(chordText: String): Chord? {
+        val normalized = chordText.replace("♯", "#").replace("♭", "b")
+        val match = chordPattern.matchEntire(normalized) ?: return null
+        return Chord(
+            root = match.groupValues[1],
+            quality = match.groupValues[2].takeIf { it.isNotEmpty() },
+            bass = match.groupValues[3].takeIf { it.isNotEmpty() }
+        )
+    }
+
+    protected open fun computeChordSpans(
+        text: String,
+        anchors: List<Pair<Chord, Int>>
+    ): List<ChordSpan> {
+        if (anchors.isEmpty()) return emptyList()
+
+        val spans = anchors.map { (chord, charIndex) ->
+            val prefix = text.takeCharCount(charIndex)
+            val column = measureMonospaceColumns(prefix)
+            ChordSpan(
+                startColumn = column,
+                chord = chord,
+                width = chord.displayName.length
+            )
+        }.sortedBy { it.startColumn }
+
+        return resolveCollisions(spans)
+    }
+
+    protected open fun resolveCollisions(spans: List<ChordSpan>): List<ChordSpan> {
+        if (spans.size <= 1) return spans
+        val resolved = mutableListOf<ChordSpan>()
+        spans.forEach { span ->
+            val adjustedColumn = when (val last = resolved.lastOrNull()) {
+                null -> span.startColumn
+                else -> max(span.startColumn, last.startColumn + last.width + 1)
+            }
+            resolved += span.copy(startColumn = adjustedColumn)
+        }
+        return resolved
+    }
+
+    private fun tokenizeText(
+        text: String,
+        anchors: List<Pair<Chord, Int>>
+    ): List<Token> {
+        if (text.isEmpty() && anchors.isEmpty()) return emptyList()
+        val tokens = mutableListOf<Token>()
+        var currentIndex = 0
+        var anchorIndex = 0
+        val sortedAnchors = anchors.sortedBy { it.second }
+
+        while (currentIndex < text.length || anchorIndex < sortedAnchors.size) {
+            val nextAnchor = sortedAnchors.getOrNull(anchorIndex)
+            val anchorPosition = nextAnchor?.second ?: Int.MAX_VALUE
+
+            if (currentIndex < anchorPosition && currentIndex < text.length) {
+                val end = minOf(anchorPosition, text.length)
+                appendSegmentTokens(
+                    segment = text.substring(currentIndex, end),
+                    tokens = tokens
+                )
+                currentIndex = end
+            }
+
+            if (nextAnchor != null && currentIndex >= anchorPosition) {
+                tokens += Token.ChordAnchor(nextAnchor.first, nextAnchor.second)
+                anchorIndex++
+            }
+
+            if (nextAnchor == null && currentIndex >= text.length) {
+                break
+            }
+        }
+
+        if (currentIndex < text.length) {
+            appendSegmentTokens(text.substring(currentIndex), tokens)
+        }
+
+        return tokens
+    }
+
+    private fun appendSegmentTokens(segment: String, tokens: MutableList<Token>) {
+        if (segment.isEmpty()) return
+        var index = 0
+        while (index < segment.length) {
+            val start = index
+            val isSpace = segment[index].isWhitespace()
+            while (index < segment.length && segment[index].isWhitespace() == isSpace) {
+                index++
+            }
+            val tokenText = segment.substring(start, index)
+            if (isSpace) {
+                tokens += Token.Space(tokenText.length)
+            } else {
+                tokens += Token.Word(tokenText)
+            }
+        }
+    }
+
+    private fun measureMonospaceColumns(text: String): Int {
+        return text.codePointCount(0, text.length)
+    }
+
+    private fun StringBuilder.codePointCount(): Int = this.toString().codePointCount(0, length)
+
+    private fun String.takeCharCount(count: Int): String {
+        if (count <= 0) return ""
+        if (count >= length) return this
+        var endIndex = 0
+        var remaining = count
+        while (endIndex < length && remaining > 0) {
+            val char = this[endIndex]
+            endIndex += if (Character.isHighSurrogate(char) && endIndex + 1 < length && Character.isLowSurrogate(this[endIndex + 1])) {
+                2
+            } else {
+                1
+            }
+            remaining--
+        }
+        return substring(0, endIndex)
+    }
+}

--- a/app/src/main/java/com/zionhuang/music/lyrics/chords/RobustChordParser.kt
+++ b/app/src/main/java/com/zionhuang/music/lyrics/chords/RobustChordParser.kt
@@ -1,0 +1,38 @@
+package com.zionhuang.music.lyrics.chords
+
+class RobustChordParser : ChordParser() {
+    override fun parseLine(input: String): LyricLine {
+        return try {
+            super.parseLine(input)
+        } catch (error: Exception) {
+            LyricLine(
+                raw = input,
+                cleanLyrics = input.replace(Regex("""\\[[^]]*]"""), ""),
+                tokens = emptyList(),
+                chordSpans = emptyList()
+            )
+        }
+    }
+
+    fun validateSongStructure(song: SongText): ValidationResult {
+        val issues = mutableListOf<String>()
+        if (song.sections.isEmpty()) {
+            issues += "Song has no content sections"
+        }
+        val totalLines = song.sections.sumOf { it.lines.size }
+        if (totalLines > 500) {
+            issues += "Song is very long (${totalLines} lines)"
+        }
+        return if (issues.isEmpty()) {
+            ValidationResult.Success
+        } else {
+            ValidationResult.Warning(issues)
+        }
+    }
+}
+
+sealed class ValidationResult {
+    object Success : ValidationResult()
+    data class Warning(val messages: List<String>) : ValidationResult()
+    data class Error(val message: String) : ValidationResult()
+}

--- a/app/src/main/java/com/zionhuang/music/lyrics/chords/SongText.kt
+++ b/app/src/main/java/com/zionhuang/music/lyrics/chords/SongText.kt
@@ -1,0 +1,68 @@
+package com.zionhuang.music.lyrics.chords
+
+/**
+ * Represents a parsed chord chart or lyric sheet that may contain multiple sections.
+ */
+data class SongText(
+    val id: String,
+    val title: String,
+    val artist: String?,
+    val sections: List<Section>
+)
+
+/**
+ * Logical grouping inside a song such as a verse or chorus.
+ */
+data class Section(
+    val tag: String?,
+    val lines: List<LyricLine>
+)
+
+/**
+ * Individual lyric line with optional chord anchors embedded.
+ */
+data class LyricLine(
+    val raw: String,
+    val cleanLyrics: String,
+    val tokens: List<Token>,
+    val chordSpans: List<ChordSpan>
+)
+
+sealed interface Token {
+    data class Word(val text: String) : Token
+    data class Space(val length: Int = 1) : Token
+    data class ChordAnchor(val chord: Chord, val charIndex: Int) : Token
+}
+
+/**
+ * Parsed representation of a chord symbol.
+ */
+data class Chord(
+    val root: String,
+    val quality: String?,
+    val bass: String?
+) {
+    val displayName: String
+        get() = buildString {
+            append(root)
+            quality?.takeIf { it.isNotEmpty() }?.let { append(it) }
+            bass?.takeIf { it.isNotEmpty() }?.let { append("/$it") }
+        }
+}
+
+/**
+ * Describes the on-screen positioning information for a rendered chord label.
+ */
+data class ChordSpan(
+    val startColumn: Int,
+    val chord: Chord,
+    val width: Int
+)
+
+fun SongText.hasLyrics(): Boolean = sections.any { section ->
+    section.lines.any { it.cleanLyrics.isNotBlank() }
+}
+
+fun SongText.hasChords(): Boolean = sections.any { section ->
+    section.lines.any { it.chordSpans.isNotEmpty() }
+}

--- a/app/src/main/java/com/zionhuang/music/ui/component/ChordLyricsContent.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/component/ChordLyricsContent.kt
@@ -1,0 +1,469 @@
+package com.zionhuang.music.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.zionhuang.music.lyrics.chords.LyricLine
+import com.zionhuang.music.lyrics.chords.SongText
+import com.zionhuang.music.lyrics.chords.hasChords
+import com.zionhuang.music.lyrics.chords.hasLyrics
+import com.zionhuang.music.ui.player.text.AutoScrollDetector
+import com.zionhuang.music.ui.player.text.PlayerAction
+import com.zionhuang.music.ui.player.text.PlayerViewModel
+import com.zionhuang.music.ui.player.text.ViewMode
+import com.zionhuang.music.ui.player.text.rememberAutoScrollController
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChordLyricsContent(
+    songText: SongText,
+    modifier: Modifier = Modifier,
+    viewModel: PlayerViewModel = viewModel(key = "ChordLyricsContent_${songText.id}")
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    LaunchedEffect(songText.id) {
+        viewModel.handleAction(PlayerAction.LoadSong(songText))
+    }
+
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    val autoScrollController = rememberAutoScrollController(listState, coroutineScope)
+
+    var showSpeedControl by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState.autoScrollEnabled, uiState.autoScrollSpeed, uiState.autoScrollPaused) {
+        if (uiState.autoScrollEnabled && !uiState.autoScrollPaused) {
+            autoScrollController.startAutoScroll(uiState.autoScrollSpeed, density)
+        } else {
+            autoScrollController.stopAutoScroll()
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            if (songText.hasLyrics() && songText.hasChords()) {
+                ViewModeSelector(
+                    currentMode = uiState.viewMode,
+                    hasLyrics = songText.hasLyrics(),
+                    hasChords = songText.hasChords(),
+                    onModeChange = { viewModel.handleAction(PlayerAction.SwitchView(it)) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 8.dp)
+                )
+            }
+
+            Box(modifier = Modifier.weight(1f, fill = true)) {
+                AutoScrollDetector(
+                    controller = autoScrollController,
+                    onPause = { viewModel.handleAction(PlayerAction.PauseAutoScroll) },
+                    onResume = { viewModel.handleAction(PlayerAction.ResumeAutoScroll) }
+                ) {
+                    when (uiState.viewMode) {
+                        ViewMode.LYRICS -> LyricsView(
+                            songText = songText,
+                            listState = listState,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                        ViewMode.CHORDS -> ChordsView(
+                            songText = songText,
+                            listState = listState,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+                }
+            }
+        }
+
+        FloatingActionButton(
+            onClick = { showSpeedControl = true },
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(16.dp)
+        ) {
+            val isRunning = uiState.autoScrollEnabled && !uiState.autoScrollPaused
+            Text(if (isRunning) "Pause" else "Scroll")
+        }
+
+        if (showSpeedControl) {
+            SpeedControlBottomSheet(
+                currentSpeed = uiState.autoScrollSpeed,
+                isEnabled = uiState.autoScrollEnabled,
+                onSpeedChange = { speed ->
+                    viewModel.handleAction(PlayerAction.SetAutoScrollSpeed(speed))
+                    if (uiState.autoScrollEnabled) {
+                        autoScrollController.startAutoScroll(speed, density)
+                    }
+                },
+                onToggleEnabled = { enabled ->
+                    viewModel.handleAction(PlayerAction.SetAutoScrollEnabled(enabled))
+                    if (enabled) {
+                        autoScrollController.startAutoScroll(uiState.autoScrollSpeed, density)
+                    } else {
+                        autoScrollController.stopAutoScroll()
+                    }
+                },
+                onDismiss = { showSpeedControl = false }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SpeedControlBottomSheet(
+    currentSpeed: Float,
+    isEnabled: Boolean,
+    onSpeedChange: (Float) -> Unit,
+    onToggleEnabled: (Boolean) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+        ) {
+            Text(
+                text = "Auto-Scroll Speed",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            SwitchRow(
+                label = "Enable Auto-Scroll",
+                checked = isEnabled,
+                onCheckedChange = onToggleEnabled
+            )
+
+            val percentage = (currentSpeed.coerceIn(0f, 1f) * 100).roundToInt()
+            Text(
+                text = "Speed: ${percentage}%",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            Slider(
+                value = currentSpeed.coerceIn(0f, 1f),
+                onValueChange = onSpeedChange,
+                enabled = isEnabled
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            PresetButtons(isEnabled = isEnabled, onSpeedChange = onSpeedChange)
+        }
+    }
+}
+
+@Composable
+private fun SwitchRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 16.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f)
+        )
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun PresetButtons(
+    isEnabled: Boolean,
+    onSpeedChange: (Float) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        PresetButton(
+            label = "Slow",
+            speed = 0.2f,
+            enabled = isEnabled,
+            onSpeedChange = onSpeedChange,
+            modifier = Modifier.weight(1f)
+        )
+        PresetButton(
+            label = "Medium",
+            speed = 0.4f,
+            enabled = isEnabled,
+            onSpeedChange = onSpeedChange,
+            modifier = Modifier.weight(1f)
+        )
+        PresetButton(
+            label = "Fast",
+            speed = 0.7f,
+            enabled = isEnabled,
+            onSpeedChange = onSpeedChange,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun PresetButton(
+    label: String,
+    speed: Float,
+    enabled: Boolean,
+    onSpeedChange: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedButton(
+        onClick = { onSpeedChange(speed) },
+        enabled = enabled,
+        modifier = modifier
+    ) {
+        Text(label)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ViewModeSelector(
+    currentMode: ViewMode,
+    hasLyrics: Boolean,
+    hasChords: Boolean,
+    onModeChange: (ViewMode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    androidx.compose.material3.SingleChoiceSegmentedButtonRow(
+        modifier = modifier
+    ) {
+        androidx.compose.material3.SegmentedButton(
+            selected = currentMode == ViewMode.LYRICS,
+            onClick = { onModeChange(ViewMode.LYRICS) },
+            enabled = hasLyrics
+        ) {
+            Text("Lyrics")
+        }
+        androidx.compose.material3.SegmentedButton(
+            selected = currentMode == ViewMode.CHORDS,
+            onClick = { onModeChange(ViewMode.CHORDS) },
+            enabled = hasChords
+        ) {
+            Text("Chords")
+        }
+    }
+}
+
+@Composable
+fun LyricsView(
+    songText: SongText,
+    listState: LazyListState,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        state = listState,
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
+        modifier = modifier.fillMaxSize()
+    ) {
+        songText.sections.forEach { section ->
+            section.tag?.let { tag ->
+                item(key = "section_${tag}") {
+                    Text(
+                        text = tag,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 8.dp)
+                    )
+                }
+            }
+            items(
+                items = section.lines,
+                key = { it.raw.hashCode() }
+            ) { line ->
+                Text(
+                    text = line.cleanLyrics,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.3f
+                    ),
+                    modifier = Modifier.padding(vertical = 2.dp)
+                )
+            }
+        }
+        if (!songText.hasLyrics()) {
+            item {
+                EmptyStateMessage(
+                    message = "No lyrics available",
+                    modifier = Modifier.padding(vertical = 24.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ChordsView(
+    songText: SongText,
+    listState: LazyListState,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        state = listState,
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
+        modifier = modifier.fillMaxSize()
+    ) {
+        songText.sections.forEach { section ->
+            section.tag?.let { tag ->
+                item(key = "section_${tag}") {
+                    Text(
+                        text = tag,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 8.dp)
+                    )
+                }
+            }
+            items(
+                items = section.lines,
+                key = { it.raw.hashCode() }
+            ) { line ->
+                ChordLyricLine(
+                    line = line,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+            }
+        }
+        if (!songText.hasChords()) {
+            item {
+                EmptyStateMessage(
+                    message = "No chords available",
+                    modifier = Modifier.padding(vertical = 24.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ChordLyricLine(
+    line: LyricLine,
+    modifier: Modifier = Modifier
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val chordStyle = MaterialTheme.typography.labelLarge.copy(
+        fontFamily = FontFamily.Monospace,
+        fontWeight = FontWeight.Bold,
+        fontSize = 14.sp
+    )
+    val density = LocalDensity.current
+    val charWidthPx = remember(line.chordSpans, chordStyle) {
+        val measurement = textMeasurer.measure("M", chordStyle)
+        measurement.size.width.toFloat().coerceAtLeast(1f)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics {
+                val chordDescription = if (line.chordSpans.isNotEmpty()) {
+                    "Chords: " + line.chordSpans.joinToString(", ") { it.chord.displayName }
+                } else ""
+                contentDescription = buildString {
+                    if (chordDescription.isNotEmpty()) {
+                        append(chordDescription)
+                        append(". ")
+                    }
+                    append("Lyrics: ${line.cleanLyrics}")
+                }
+            }
+    ) {
+        if (line.chordSpans.isNotEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(24.dp)
+            ) {
+                line.chordSpans.forEach { span ->
+                    val xOffset = with(density) { (charWidthPx * span.startColumn).toDp() }
+                    Text(
+                        text = span.chord.displayName,
+                        style = chordStyle,
+                        color = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier.offset(x = xOffset)
+                    )
+                }
+            }
+        }
+
+        Text(
+            text = line.cleanLyrics,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.3f
+            ),
+            modifier = Modifier.padding(top = if (line.chordSpans.isNotEmpty()) 4.dp else 0.dp)
+        )
+    }
+}
+
+@Composable
+private fun EmptyStateMessage(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = message,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+    )
+}

--- a/app/src/main/java/com/zionhuang/music/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/component/Lyrics.kt
@@ -54,8 +54,11 @@ import com.zionhuang.music.constants.TranslateLyricsKey
 import com.zionhuang.music.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
 import com.zionhuang.music.lyrics.LyricsEntry
 import com.zionhuang.music.lyrics.LyricsEntry.Companion.HEAD_LYRICS_ENTRY
+import com.zionhuang.music.lyrics.LyricsUtils
 import com.zionhuang.music.lyrics.LyricsUtils.findCurrentLineIndex
 import com.zionhuang.music.lyrics.LyricsUtils.parseLyrics
+import com.zionhuang.music.lyrics.chords.RobustChordParser
+import com.zionhuang.music.lyrics.chords.hasChords
 import com.zionhuang.music.ui.component.shimmer.ShimmerHost
 import com.zionhuang.music.ui.component.shimmer.TextPlaceholder
 import com.zionhuang.music.ui.menu.LyricsMenu
@@ -75,6 +78,7 @@ fun Lyrics(
     val playerConnection = LocalPlayerConnection.current ?: return
     val menuState = LocalMenuState.current
     val density = LocalDensity.current
+    val chordParser = remember { RobustChordParser() }
 
     val playerTextAlignment by rememberEnumPreference(PlayerTextAlignmentKey, PlayerTextAlignment.CENTER)
     var translationEnabled by rememberPreference(TranslateLyricsKey, false)
@@ -87,14 +91,43 @@ fun Lyrics(
         else lyricsEntity?.lyrics
     }
 
-    val lines = remember(lyrics) {
-        if (lyrics == null || lyrics == LYRICS_NOT_FOUND) emptyList()
-        else if (lyrics.startsWith("[")) listOf(HEAD_LYRICS_ENTRY) + parseLyrics(lyrics)
-        else lyrics.lines().mapIndexed { index, line -> LyricsEntry(index * 100L, line) }
+    val hasTimestamps = remember(lyrics) {
+        !lyrics.isNullOrEmpty() && LyricsUtils.LINE_REGEX.containsMatchIn(lyrics)
     }
-    val isSynced = remember(lyrics) {
-        !lyrics.isNullOrEmpty() && lyrics.startsWith("[")
+
+    val chordSongText = remember(lyrics, translating, hasTimestamps, mediaMetadata) {
+        val raw = lyrics
+        if (raw.isNullOrBlank() || translating || hasTimestamps) {
+            null
+        } else if (chordParser.containsChordNotation(raw)) {
+            val id = mediaMetadata?.id ?: raw.hashCode().toString()
+            val title = mediaMetadata?.title ?: id
+            val artist = mediaMetadata?.artists
+                ?.joinToString(separator = ", ") { it.name }
+                ?.takeIf { it.isNotBlank() }
+            runCatching {
+                chordParser.parseSongText(
+                    id = id,
+                    title = title,
+                    artist = artist,
+                    rawText = raw
+                )
+            }.getOrNull()
+        } else {
+            null
+        }
     }
+    val showChordContent = chordSongText?.hasChords() == true
+
+    val lines = remember(lyrics, hasTimestamps, showChordContent) {
+        when {
+            lyrics == null || lyrics == LYRICS_NOT_FOUND -> emptyList()
+            hasTimestamps -> listOf(HEAD_LYRICS_ENTRY) + parseLyrics(lyrics)
+            showChordContent -> emptyList()
+            else -> lyrics.lines().mapIndexed { index, line -> LyricsEntry(index * 100L, line) }
+        }
+    }
+    val isSynced = hasTimestamps
 
     var currentLineIndex by remember {
         mutableIntStateOf(-1)
@@ -112,8 +145,8 @@ fun Lyrics(
         mutableStateOf(false)
     }
 
-    LaunchedEffect(lyrics) {
-        if (lyrics.isNullOrEmpty() || !lyrics.startsWith("[")) {
+    LaunchedEffect(lyrics, hasTimestamps) {
+        if (lyrics.isNullOrEmpty() || !hasTimestamps) {
             currentLineIndex = -1
             return@LaunchedEffect
         }
@@ -150,12 +183,57 @@ fun Lyrics(
         }
     }
 
-    BoxWithConstraints(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .fillMaxSize()
-            .padding(bottom = 12.dp)
-    ) {
+    if (showChordContent && chordSongText != null) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = modifier
+                .fillMaxSize()
+                .padding(bottom = 12.dp)
+        ) {
+            ChordLyricsContent(
+                songText = chordSongText,
+                modifier = Modifier.fillMaxSize()
+            )
+            mediaMetadata?.let { mediaMetadata ->
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(end = 12.dp)
+                ) {
+                    if (BuildConfig.FLAVOR != "foss") {
+                        IconButton(
+                            onClick = {
+                                translationEnabled = !translationEnabled
+                            }
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.translate),
+                                contentDescription = null,
+                                tint = LocalContentColor.current.copy(alpha = if (translationEnabled) 1f else 0.3f)
+                            )
+                        }
+                    }
+
+                    IconButton(
+                        onClick = {
+                            menuState.show {
+                                LyricsMenu(
+                                    lyricsProvider = { lyricsEntity },
+                                    mediaMetadataProvider = { mediaMetadata },
+                                    onDismiss = menuState::dismiss
+                                )
+                            }
+                        }
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.more_horiz),
+                            contentDescription = null
+                        )
+                    }
+                }
+            }
+        }
+    } else {
         LazyColumn(
             state = lazyListState,
             contentPadding = WindowInsets.systemBars

--- a/app/src/main/java/com/zionhuang/music/ui/player/text/AutoScrollController.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/text/AutoScrollController.kt
@@ -1,0 +1,137 @@
+package com.zionhuang.music.ui.player.text
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.withFrameNanos
+
+class AutoScrollController(
+    private val listState: LazyListState,
+    private val coroutineScope: CoroutineScope
+) {
+    private var scrollJob: Job? = null
+    @Volatile
+    private var isUserInteracting: Boolean = false
+
+    fun startAutoScroll(speedFactor: Float, density: Density) {
+        val normalizedSpeed = speedFactor.coerceIn(0f, 1f)
+        stopAutoScroll()
+        if (normalizedSpeed <= 0f) return
+        scrollJob = coroutineScope.launch {
+            val baseSpeed = 40.dp
+            var lastFrameTime: Long? = null
+            while (isActive) {
+                if (isUserInteracting) {
+                    lastFrameTime = null
+                    delay(100)
+                    continue
+                }
+                val frameTime = withFrameNanos { it }
+                val previous = lastFrameTime
+                lastFrameTime = frameTime
+                if (previous != null) {
+                    val deltaSeconds = (frameTime - previous) / 1_000_000_000f
+                    if (deltaSeconds > 0f) {
+                        val speedPixelsPerSecond = with(density) { baseSpeed.toPx() } * normalizedSpeed
+                        val scrollDistance = speedPixelsPerSecond * deltaSeconds
+                        if (scrollDistance != 0f) {
+                            listState.scrollBySafely(scrollDistance)
+                        }
+                    }
+                }
+                delay(16)
+            }
+        }
+    }
+
+    fun stopAutoScroll() {
+        scrollJob?.cancel()
+        scrollJob = null
+    }
+
+    fun pauseForUserInteraction() {
+        isUserInteracting = true
+    }
+
+    fun resumeAfterUserInteraction() {
+        isUserInteracting = false
+    }
+
+    private suspend fun LazyListState.scrollBySafely(distance: Float) {
+        if (distance == 0f) return
+        runCatching {
+            scrollBy(distance)
+        }
+    }
+}
+
+@Composable
+fun rememberAutoScrollController(listState: LazyListState, coroutineScope: CoroutineScope): AutoScrollController {
+    return remember(listState, coroutineScope) {
+        AutoScrollController(listState, coroutineScope)
+    }
+}
+
+@Composable
+fun AutoScrollDetector(
+    controller: AutoScrollController,
+    onPause: () -> Unit = {},
+    onResume: () -> Unit = {},
+    content: @Composable () -> Unit
+) {
+    var isDragging by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isDragging) {
+        if (isDragging) {
+            controller.pauseForUserInteraction()
+            onPause()
+        } else {
+            delay(500)
+            controller.resumeAfterUserInteraction()
+            onResume()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = { isDragging = true },
+                    onDragEnd = { isDragging = false },
+                    onDragCancel = { isDragging = false }
+                ) { _, _ -> }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onPress = {
+                        controller.pauseForUserInteraction()
+                        onPause()
+                        try {
+                            tryAwaitRelease()
+                        } finally {
+                            controller.resumeAfterUserInteraction()
+                            onResume()
+                        }
+                    }
+                )
+            }
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/zionhuang/music/ui/player/text/PlayerTextState.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/text/PlayerTextState.kt
@@ -1,0 +1,95 @@
+package com.zionhuang.music.ui.player.text
+
+import androidx.lifecycle.ViewModel
+import com.zionhuang.music.lyrics.chords.SongText
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+enum class ViewMode { LYRICS, CHORDS }
+
+data class PlayerUiState(
+    val currentSong: SongText? = null,
+    val viewMode: ViewMode = ViewMode.LYRICS,
+    val autoScrollEnabled: Boolean = false,
+    val autoScrollSpeed: Float = 0.4f,
+    val autoScrollPaused: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+sealed interface PlayerAction {
+    data class LoadSong(val song: SongText) : PlayerAction
+    data class SwitchView(val mode: ViewMode) : PlayerAction
+    data class SetAutoScrollEnabled(val enabled: Boolean) : PlayerAction
+    data class SetAutoScrollSpeed(val speed: Float) : PlayerAction
+    object PauseAutoScroll : PlayerAction
+    object ResumeAutoScroll : PlayerAction
+}
+
+class PlayerViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(PlayerUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun handleAction(action: PlayerAction) {
+        when (action) {
+            is PlayerAction.LoadSong -> setSong(action.song)
+            is PlayerAction.SwitchView -> updateViewMode(action.mode)
+            is PlayerAction.SetAutoScrollEnabled -> toggleAutoScroll(action.enabled)
+            is PlayerAction.SetAutoScrollSpeed -> updateScrollSpeed(action.speed)
+            PlayerAction.PauseAutoScroll -> updateAutoScrollPaused(true)
+            PlayerAction.ResumeAutoScroll -> updateAutoScrollPaused(false)
+        }
+    }
+
+    fun setSong(songText: SongText?) {
+        if (songText == null) {
+            _uiState.update { it.copy(currentSong = null, isLoading = false, error = null) }
+            return
+        }
+        _uiState.update {
+            it.copy(
+                currentSong = songText,
+                isLoading = false,
+                error = null,
+                viewMode = determineInitialView(songText)
+            )
+        }
+    }
+
+    private fun updateViewMode(mode: ViewMode) {
+        _uiState.update { it.copy(viewMode = mode) }
+    }
+
+    private fun toggleAutoScroll(enabled: Boolean) {
+        _uiState.update {
+            it.copy(autoScrollEnabled = enabled, autoScrollPaused = false)
+        }
+    }
+
+    private fun updateScrollSpeed(speed: Float) {
+        val normalized = speed.coerceIn(0f, 1f)
+        _uiState.update { it.copy(autoScrollSpeed = normalized) }
+    }
+
+    private fun updateAutoScrollPaused(paused: Boolean) {
+        _uiState.update { current ->
+            if (current.autoScrollPaused == paused) current
+            else current.copy(autoScrollPaused = paused)
+        }
+    }
+
+    private fun determineInitialView(song: SongText): ViewMode {
+        val hasChords = song.sections.any { section ->
+            section.lines.any { it.chordSpans.isNotEmpty() }
+        }
+        val hasLyrics = song.sections.any { section ->
+            section.lines.any { it.cleanLyrics.isNotBlank() }
+        }
+        return when {
+            hasChords -> ViewMode.CHORDS
+            hasLyrics -> ViewMode.LYRICS
+            else -> ViewMode.LYRICS
+        }
+    }
+}

--- a/app/src/test/java/com/zionhuang/music/lyrics/chords/ChordParserTest.kt
+++ b/app/src/test/java/com/zionhuang/music/lyrics/chords/ChordParserTest.kt
@@ -1,0 +1,46 @@
+package com.zionhuang.music.lyrics.chords
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChordParserTest {
+    private val parser = ChordParser()
+
+    @Test
+    fun parseSimpleChordLine() {
+        val result = parser.parseLine("Twinkle [Am]twinkle, little [C]star")
+
+        assertEquals("Twinkle twinkle, little star", result.cleanLyrics)
+        assertEquals(2, result.chordSpans.size)
+        assertEquals("Am", result.chordSpans[0].chord.displayName)
+        assertEquals("C", result.chordSpans[1].chord.displayName)
+        assertTrue(result.chordSpans[1].startColumn > result.chordSpans[0].startColumn)
+    }
+
+    @Test
+    fun parseThaiLyricsWithChord() {
+        val result = parser.parseLine("ทะเ[Em7]ลแสนไกลไม่มีสิ้นสุด")
+
+        assertEquals("ทะเลแสนไกลไม่มีสิ้นสุด", result.cleanLyrics)
+        assertEquals(1, result.chordSpans.size)
+        assertEquals("Em7", result.chordSpans[0].chord.displayName)
+        assertTrue(result.chordSpans[0].startColumn >= 0)
+    }
+
+    @Test
+    fun handleAdjacentChordsWithoutCollision() {
+        val result = parser.parseLine("Start [C][G] end")
+
+        assertEquals(2, result.chordSpans.size)
+        assertTrue(result.chordSpans[1].startColumn >= result.chordSpans[0].startColumn)
+    }
+
+    @Test
+    fun ignoreInvalidChords() {
+        val result = parser.parseLine("Text [INVALID_CHORD] more text")
+
+        assertEquals("Text  more text", result.cleanLyrics)
+        assertTrue(result.chordSpans.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- add chord parsing data models and robust parser for chord-aware song text handling
- introduce UI state, auto-scroll utilities, and a Compose chord/lyrics layout for player text screens
- integrate chord detection into the lyrics component and cover parsing with unit tests

## Testing
- ❌ `./gradlew testDebugUnitTest` *(fails: required JDK 17 toolchain is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cedca0a218832a834ac406d0cfaf21